### PR TITLE
Refactoring, JSDoc, Integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Interface Checker
 
-A node library to store interface definitions and check to see if an object matches a defined interface.  Can match method names and optionally parameter count.
+A node library to store interface definitions and check to see if an object matches a defined interface.
+Can match method names and optionally parameter count.
 
 
 ## How to install ?
@@ -20,8 +21,77 @@ $ component install ryanzec/interface-checker
 
 # Quick Start
 
-TBD
+## Define your interface
+
+Here is how to define an interface
+
+```javascript
+var interface = {
+	myKeyName: { type: 'string' },
+	myOtherKeyName: { type: 'function' },
+	yetAnotherKeyName: { type: 'function', numberOfParams: 2 },
+};
+```
+
+* The `numberOfParams` property is optional for the methods.
+* The standard JavaScript types are used, which are: (please respect the case)
+  * `object`
+  * `string`
+  * `boolean`
+  * `number`
+  * `undefined`
+
+Once the object built, just give it to the interface checker as follow:
+
+```javascript
+var interfaceChecker = require('interface-checker');
+interfaceChecker.define('myInterfaceName', interface);
+```
+
+
+## Validate objects
+
+Once you have defined one (or more) interface, you can check if some objects are valid regarding interfaces you have
+defined. For example, with the previous interface:
+
+```javascript
+var object = {
+	myKeyName: 'Hello',
+	myOtherKeyName: function () { console.log('Hello world !'); },
+	yetAnotherKeyName: function (a, b) { console.log(a, b); }
+};
+
+try {
+	interfaceChecker.check(object, 'myInterfaceName');
+} catch (expt) {
+	console.log(expt.message); // `doesNotRespectInterface`
+	console.log(JSON.stringify(expt.errors, null, 2)); // JSON describing the errors
+}
+```
+
+Below are the properties `expt.errors` will have if an expection gets thrown:
+* `missingMethods`: Array of the missing methods
+* `missingProperties`: Array of the missing properties
+* `invalidType`: Array of objects such as
+  ```javascript
+  {
+    key: 'theKeyName'
+    expected: 'expectedType',
+    actual: 'actualType'
+  }
+  ```
+* `parameterMismatch`: Array of objects such as
+  ```javascript
+  {
+  	key: 'theKeyName',
+  	expected: 'expectedNumOfParams',
+  	actual: 'actualNumOfParams'
+  }
+  ```
+
+
 
 ## LICENSE
 
 MIT
+)

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,76 +1,107 @@
-require('string-format');
 var interfaces = {};
 
-module.exports = {
-  define: function(interfaceName, methodList) {
-    interfaces[interfaceName] = methodList;
-  },
-  has: function(checkObject, interfaceName) {
-    var objectKeys = Object.keys(checkObject);
-    var errors = {};
 
-    if(!interfaces[interfaceName]) {
-      throw new Error('There is not interface define as {0}'.format(interfaceName));
-    }
+/**
+ * @desc Define and record an interface.
+ *
+ * @param  {String}   name       - The name for the interface.
+ * @param  {Object[]} definition - The actual definition.
+ */
+function define(name, definition) {
+  interfaces[name] = definition;
+}
 
-    var checkList = interfaces[interfaceName];
-    var checkDefinition;
 
-    for(var x = 0; x < checkList.length; x += 1) {
-      checkDefinition = checkList[x].split(':');
+/**
+ * @desc Check if an object respects a given interface definition.
+ *
+ * @param  {Object}  checkObject   - The object to test.
+ * @param  {String}  interfaceName - The name of the interface to take as a reference.
+ *
+ * @throws {Error} `doesNotRespectInterface`
+ *                 If the object does not respect the interface definition, an expection is thrown.
+*                    `Error.message` is an object with the following properties:
+*                    * `missingMethods` (Array)
+*                    * `missingProperties` (Array)
+*                    * `invalidType` (Array)
+*                    * `parameterMismatch` (Array)
+ */
+function check(checkObject, interfaceName) {
+  var checkList = interfaces[interfaceName];
 
-      //check that method exists
-      if(!checkDefinition[1] || checkDefinition[1] !== 'p') {
-        if(objectKeys.indexOf(checkDefinition[0]) === -1) {
-          if(!errors.missingMethods) {
-            errors.missingMethods = [];
-          }
-
-          errors.missingMethods.push(checkDefinition[0]);
-          continue;
-        } else if(typeof checkObject[checkDefinition[0]] !== 'function') {
-          if(!errors.invalidType) {
-            errors.invalidType = {};
-          }
-
-          errors.invalidType[checkDefinition[0]] = 'method';
-          continue;
-        }
-
-        //check that parameter count matches if given
-        if((checkDefinition[1] || checkDefinition[1] === '0') && checkDefinition[1] != checkObject[checkDefinition[0]].length) {
-          if(!errors.parameterMismatch) {
-            errors.parameterMismatch = [];
-          }
-
-          errors.parameterMismatch.push('{0} should have {1} parameters but it currently has {2} parameters'.format(
-          checkDefinition[0],
-          checkDefinition[1],
-          checkObject[checkDefinition[0]].length)
-          );
-          continue;
-        }
-      } else {
-        if(objectKeys.indexOf(checkDefinition[0]) === -1) {
-          if(!errors.missingProperties) {
-            errors.missingProperties = [];
-          }
-
-          errors.missingProperties.push(checkDefinition[0]);
-          continue;
-        } else if(typeof checkObject[checkDefinition[0]] === 'function') {
-          if(!errors.invalidType) {
-            errors.invalidType = {};
-          }
-
-          errors.invalidType[checkDefinition[0]] = 'property';
-          continue;
-        }
-      }
-
-      checkDefinition = null;
-    }
-
-    return Object.keys(errors).length === 0 ? true : errors;
+  // Does `interfaceName` exist ?
+  if (!checkList) {
+    throw new Error('There is not interface define as {0}'.format(interfaceName));
   }
-};
+
+  // The object that is gonna be returned in case of errors
+  var errors = {
+    missingMethods: [],
+    missingProperties: [],
+    invalidType: [],
+    parameterMismatch: []
+  };
+
+  for (var keyName in checkList) {
+    var checkItem = checkList[keyName];
+
+    var expectedType = checkItem.type;
+    var isMethod = (expectedType === 'function');
+
+    var objectProperty = checkObject[keyName];
+    var objectPropertyType = typeof(objectProperty);
+
+    // Check if there are missing properties or methods
+    if (objectProperty === undefined) {
+      var targetedError = isMethod ? errors.missingMethods : errors.missingProperties;
+      targetedError.push(keyName);
+      continue;
+    }
+
+    // Check for invalid types
+    if(objectPropertyType !== expectedType) {
+      errors.invalidType.push({
+        key: keyName,
+        expected: expectedType,
+        actual: objectPropertyType
+      });
+      continue;
+    }
+
+    // If a method and if specified, count the number of parameters
+    var numberOfParams = checkItem.numberOfParams;
+    var actualNumberOfParams = objectProperty.length;
+    if ((numberOfParams !== undefined) && isMethod && (numberOfParams !== actualNumberOfParams)) {
+      errors.parameterMismatch.push({
+        key: keyName,
+        expected: numberOfParams,
+        actual: actualNumberOfParams
+      });
+      continue;
+    }
+  }
+
+  // Is there an error ?
+  var hasError =
+    errors.missingMethods.length > 0 ||
+    errors.missingProperties.length > 0 ||
+    errors.invalidType.length > 0 ||
+    errors.parameterMismatch.length > 0;
+
+  // return hasError ? errors : true;
+  if (hasError) {
+    var exception = new Error('doesNotRespectInterface');
+    exception.errors = errors;
+    throw exception;
+  }
+}
+
+
+
+
+//////////////////////
+// Exposed function //
+//////////////////////
+
+exports.define = define;
+exports.check = check;

--- a/package.json
+++ b/package.json
@@ -19,9 +19,6 @@
     "email" : "code@ryanzec.com",
     "url" : "http://www.ryanzec.com"
   },
-  "dependencies": {
-    "string-format": "0.2.1"
-  },
   "devDependencies": {
     "co": "3.0.6",
     "mocha": "1.18.2",

--- a/test/bdd.js
+++ b/test/bdd.js
@@ -1,0 +1,269 @@
+/**
+ * In order to run the tests below, first ensure you did install `mocha` via NPM and run the following command:
+ * 
+ * ```bash
+ * ./node_modules/.bin/mocha --check-leaks -u bdd ./test/bdd.js
+ * ```
+ */
+
+
+var assert = require('assert');
+var path = require('path');
+
+var interfaceCheckerPath = path.resolve(__dirname, '../lib')
+var interfaceChecker;
+
+
+describe('Method interfacing', function () {
+	beforeEach(function () {
+		// Reinitialize the interface checker
+		interfaceChecker = require(interfaceCheckerPath);
+	});
+
+	it('Validate a method without any parameter specification', function () {
+		// Interface defintion
+		var interfaceDefinition = {
+			helloWorld: { type: 'function' }
+		};
+		interfaceChecker.define('helloWorld', interfaceDefinition);
+
+		// Check
+		var object = {
+			name: 'Stouf',
+			helloWorld: function () { console.log('Hello world !'); }
+		};
+
+		assert.doesNotThrow(function () {
+			interfaceChecker.check(object, 'helloWorld');
+		}, 'The interface is not respected');
+	});
+
+	it('Invalidate an object which does not have the expected method', function () {
+		// Interface defintion
+		var interfaceDefinition = {
+			helloWorld: { type: 'function' }
+		};
+		interfaceChecker.define('helloWorld', interfaceDefinition);
+
+		// Check
+		var object = {
+			name: 'Stouf',
+		};
+
+		var errorMessage;
+		assert.throws(function () {
+			interfaceChecker.check(object, 'helloWorld');
+		}, function (error) {
+			if (error.message !== 'doesNotRespectInterface') {
+				errorMessage = 'Unexpected exception';
+				return false;
+			}
+			if (error.errors.missingMethods.length !== 1) {
+				errorMessage = 'Should have one missing method';
+				return false;
+			}
+			if (error.errors.missingMethods[0] !== 'helloWorld') {
+				errorMessage = 'Not the expected missing method';
+				return false;
+			}
+			return true;
+		}, errorMessage);
+	});
+
+	it('Validate a method with a number of parameters specified', function () {
+		// Interface defintion
+		var interfaceDefinition = {
+			helloWorld: { type: 'function', numberOfParams: 2 }
+		};
+		interfaceChecker.define('helloWorld', interfaceDefinition);
+
+		// Check
+		var object = {
+			name: 'Stouf',
+			helloWorld: function (a, b) { console.log('Hello world !', a, b); }
+		};
+		assert.doesNotThrow(function () {
+			interfaceChecker.check(object, 'helloWorld');
+		}, 'The interface is not respected');
+	});
+
+	it('Invalidate a method with an incorrect number of parameters', function () {
+		// Interface defintion
+		var interfaceDefinition = {
+			helloWorld: { type: 'function', numberOfParams: 2 }
+		};
+		interfaceChecker.define('helloWorld', interfaceDefinition);
+
+		// Check
+		var object = {
+			name: 'Stouf',
+			helloWorld: function () { console.log('Hello world !'); }
+		};
+
+		var errorMessage;
+		assert.throws(function () {
+			interfaceChecker.check(object, 'helloWorld');
+		}, function (error) {
+			if (error.message !== 'doesNotRespectInterface') {
+				errorMessage = 'Unexpected exception';
+				return false;
+			}
+			if (error.errors.parameterMismatch.length !== 1) {
+				errorMessage = 'Should have one mismatch parameters method';
+				return false;
+			}
+			if (error.errors.parameterMismatch[0].key !== 'helloWorld') {
+				errorMessage = 'Not the expected mismatch';
+				return false;
+			}
+			if (error.errors.parameterMismatch[0].expected !== 2) {
+				errorMessage = 'invalid expected number of params';
+				return false;
+			}
+			if (error.errors.parameterMismatch[0].actual !== 0) {
+				errorMessage = 'invalid actual number of params';
+				return false;
+			}
+			return true;
+		}, errorMessage);
+	});
+
+	it('Invalidate a method which is actually a string', function () {
+		// Interface defintion
+		var interfaceDefinition = {
+			helloWorld: { type: 'function', numberOfParams: 2 }
+		};
+		interfaceChecker.define('helloWorld', interfaceDefinition);
+
+		// Check
+		var object = {
+			name: 'Stouf',
+			helloWorld: 'Hello world !'
+		};
+
+		var errorMessage;
+		assert.throws(function () {
+			interfaceChecker.check(object, 'helloWorld');
+		}, function (error) {
+			if (error.message !== 'doesNotRespectInterface') {
+				errorMessage = 'Unexpected exception';
+				return false;
+			}
+			if (error.errors.invalidType.length !== 1) {
+				errorMessage = 'Should have one invalid type';
+				return false;
+			}
+			if (error.errors.invalidType[0].key !== 'helloWorld') {
+				errorMessage = 'Not the expected invalid type';
+				return false;
+			}
+			if (error.errors.invalidType[0].expected !== 'function') {
+				errorMessage = 'invalid expected type';
+				return false;
+			}
+			if (error.errors.invalidType[0].actual !== 'string') {
+				errorMessage = 'invalid actual type';
+				return false;
+			}
+			return true;
+		}, errorMessage);
+	});
+});
+
+
+describe('Property interfacing', function () {
+	beforeEach(function () {
+		// Reinitialize the interface checker
+		interfaceChecker = require(interfaceCheckerPath);
+	});
+
+	it('Validate a object with the expected property', function () {
+		// Interface defintion
+		var interfaceDefinition = {
+			name: { type: 'string' }
+		};
+		interfaceChecker.define('test', interfaceDefinition);
+
+		// Check
+		var object = {
+			name: 'Stouf',
+			helloWorld: function () { console.log('Hello world !'); }
+		};
+
+		assert.doesNotThrow(function () {
+			interfaceChecker.check(object, 'test')
+		}, 'The interface is not respected');
+	});
+
+	it('Invalidate an object which does not have the expected property', function () {
+		// Interface defintion
+		var interfaceDefinition = {
+			name: { type: 'string' }
+		};
+		interfaceChecker.define('test', interfaceDefinition);
+
+		// Check
+		var object = {
+			helloWorld: function () { console.log('Hello world !'); }
+		};
+
+		var errorMessage;
+		assert.throws(function () {
+			interfaceChecker.check(object, 'test');
+		}, function (error) {
+			if (error.message !== 'doesNotRespectInterface') {
+				errorMessage = 'Unexpected exception';
+				return false;
+			}
+			if (error.errors.missingProperties.length !== 1) {
+				errorMessage = 'Should have one missing property';
+				return false;
+			}
+			if (error.errors.missingProperties[0] !== 'name') {
+				errorMessage = 'Not the expected missing property';
+				return false;
+			}
+			return true;
+		}, errorMessage);
+	});
+
+	it('Invalidate a property of type `string` which is actually a `boolean`', function () {
+		// Interface defintion
+		var interfaceDefinition = {
+			name: { type: 'string' }
+		};
+		interfaceChecker.define('test', interfaceDefinition);
+
+		// Check
+		var object = {
+			name: true
+		};
+
+		var errorMessage;
+		assert.throws(function () {
+			interfaceChecker.check(object, 'test');
+		}, function (error) {
+			if (error.message !== 'doesNotRespectInterface') {
+				errorMessage = 'Unexpected exception';
+				return false;
+			}
+			if (error.errors.invalidType.length !== 1) {
+				errorMessage = 'Should have one invalid type';
+				return false;
+			}
+			if (error.errors.invalidType[0].key !== 'name') {
+				errorMessage = 'Not the expected invalid type';
+				return false;
+			}
+			if (error.errors.invalidType[0].expected !== 'string') {
+				errorMessage = 'invalid expected type';
+				return false;
+			}
+			if (error.errors.invalidType[0].actual !== 'boolean') {
+				errorMessage = 'invalid actual type';
+				return false;
+			}
+			return true;
+		}, errorMessage);
+	});
+});


### PR DESCRIPTION
# Refactoring, JSDoc, Integration tests
## What is in ?
### Refactoring

The code has been refactored to something (to me) more readable. Also, for the `has` function, instead of returning `true` in case of a success and an object in case of a failure, the function now throws an exception in case of a failure, with the same object as before summing up the errors that occurred.
Because of the fact we do not return a boolean value anymore but throw an exception, the function has been renamed to `check`.
### Documentation
- The `README.md` file has been updated
### Integration tests

Some integration tests using Mocha have been written. Some tests did already exist, but I could not run those (mostly because of the `function*` syntax). Thus, this section is fully opened to discussion; this Pull Request contains multiple files for testing purpose whereas only one should be enough.

To launch the tests coming with this Pull Request, please follow the instructions at the top of the concerned file.
### Dependencies

The `string-format` package has been removed from the dependency list.
